### PR TITLE
Add AWS power commands

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -145,6 +145,7 @@ class Job < BaseHashieDashModel
       script = ticket.command.lookup_script(*node.ranks)
       envs = node.params
         .tap { |e| e['name'] = node.name }
+        .tap { |e| e['command'] = ticket.command.name }
         .stringify_keys
       DEFAULT_LOGGER.info <<~INFO
 

--- a/libexec/power-cycle/aws.sh
+++ b/libexec/power-cycle/aws.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z "${ec2_id}" ]]; then
+    echo "The ec2_id for node '$name' has not been set!" >&2
+    exit 1
+fi
+if [[ -z "${aws_region}" ]]; then
+    echo "The aws_region for node '$name' has not been set!" >&2
+    exit 1
+fi
+
+aws ec2 reboot-instances  \
+    --instance-ids "${ec2_id}" \
+    --region "${aws_region}"

--- a/libexec/power-cycle/default.sh
+++ b/libexec/power-cycle/default.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >&2 <<EOF
+The default script for ${command} is not supported.  Specify an appropriate rank
+for ${name}.
+EOF
+exit 1

--- a/libexec/power-cycle/metadata.yaml
+++ b/libexec/power-cycle/metadata.yaml
@@ -1,0 +1,5 @@
+help:
+  summary: 'Power cycle a node or group'
+  description: >
+    Power cycle (reboot) the specified node or all nodes in the specified group.
+

--- a/libexec/power-off/aws.sh
+++ b/libexec/power-off/aws.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z "${ec2_id}" ]]; then
+    echo "The ec2_id for node '$name' has not been set!" >&2
+    exit 1
+fi
+if [[ -z "${aws_region}" ]]; then
+    echo "The aws_region for node '$name' has not been set!" >&2
+    exit 1
+fi
+
+aws ec2 stop-instances  \
+    --instance-ids "${ec2_id}" \
+    --region "${aws_region}"

--- a/libexec/power-off/default.sh
+++ b/libexec/power-off/default.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >&2 <<EOF
+The default script for ${command} is not supported.  Specify an appropriate rank
+for ${name}.
+EOF
+exit 1

--- a/libexec/power-off/metadata.yaml
+++ b/libexec/power-off/metadata.yaml
@@ -1,0 +1,5 @@
+help:
+  summary: 'Power off a node or group'
+  description: >
+    Power off the specified node or all nodes in the specified group.
+

--- a/libexec/power-on/aws.sh
+++ b/libexec/power-on/aws.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z "${ec2_id}" ]]; then
+    echo "The ec2_id for node '$name' has not been set!" >&2
+    exit 1
+fi
+if [[ -z "${aws_region}" ]]; then
+    echo "The aws_region for node '$name' has not been set!" >&2
+    exit 1
+fi
+
+aws ec2 start-instances  \
+    --instance-ids "${ec2_id}" \
+    --region "${aws_region}"

--- a/libexec/power-on/default.sh
+++ b/libexec/power-on/default.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >&2 <<EOF
+The default script for ${command} is not supported.  Specify an appropriate rank
+for ${name}.
+EOF
+exit 1

--- a/libexec/power-on/metadata.yaml
+++ b/libexec/power-on/metadata.yaml
@@ -1,0 +1,5 @@
+help:
+  summary: 'Power on a node or group'
+  description: >
+    Power on the specified node or all nodes in the specified group.
+

--- a/libexec/power-status/aws.sh
+++ b/libexec/power-status/aws.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ -z "${ec2_id}" ]]; then
+    echo "The ec2_id for node '$name' has not been set!" >&2
+    exit 1
+fi
+if [[ -z "${aws_region}" ]]; then
+    echo "The aws_region for node '$name' has not been set!" >&2
+    exit 1
+fi
+
+status=$(aws ec2 describe-instances \
+                 --instance-ids "${ec2_id}" \
+                 --region "${aws_region}" \
+                 --query Reservations[0].Instances[0].State.Name
+                 )
+
+case "$status" in
+    "running")
+        echo ON
+        exit 0
+        ;;
+    "stopped")
+        echo OFF
+        exit 123
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/libexec/power-status/default.sh
+++ b/libexec/power-status/default.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat >&2 <<EOF
+The default script for ${command} is not supported.  Specify an appropriate rank
+for ${name}.
+EOF
+exit 1

--- a/libexec/power-status/metadata.yaml
+++ b/libexec/power-status/metadata.yaml
@@ -1,0 +1,5 @@
+help:
+  summary: 'Get the power status for a node or group'
+  description: >
+    Get the power status for the specified node or all nodes in the specified group.
+


### PR DESCRIPTION
The supported commands are power-on, power-off, power-cycle and power-status.  The only supported platform (rank) is aws (ec2).